### PR TITLE
Fix "Melffy of the Forest" string

### DIFF
--- a/c30439101.lua
+++ b/c30439101.lua
@@ -16,7 +16,7 @@ function c30439101.initial_effect(c)
 	c:RegisterEffect(e1)
 	--disable
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(41232647,1))
+	e2:SetDescription(aux.Stringid(30439101,1))
 	e2:SetCategory(CATEGORY_DISABLE)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_CARD_TARGET)


### PR DESCRIPTION
2nd effect was pointing to "House Dragonmaid" instead of "Melffy of the Forest"